### PR TITLE
More flexibility when executing outside IHostedService

### DIFF
--- a/src/Tingle.PeriodicTasks.AspNetCore/PeriodicTasksEndpointsHandler.cs
+++ b/src/Tingle.PeriodicTasks.AspNetCore/PeriodicTasksEndpointsHandler.cs
@@ -48,11 +48,10 @@ internal class PeriodicTasksEndpointsHandler
 
         // execute
         var cancellationToken = context.RequestAborted;
-        var t = runner.ExecuteAsync(name: name, throwOnError: request.Throw, cancellationToken: cancellationToken);
-        if (request.Wait)
-        {
-            await t.ConfigureAwait(false);
-        }
+        await runner.ExecuteAsync(name: name,
+                                  throwOnError: request.Throw,
+                                  awaitExecution: request.Wait,
+                                  cancellationToken: cancellationToken).ConfigureAwait(false);
 
         PeriodicTaskExecutionAttempt? attempt = null; // when attempt is offered, use it
         return Results.Ok(attempt);

--- a/src/Tingle.PeriodicTasks.EventBus/TriggerPeriodicTaskEventConsumer.cs
+++ b/src/Tingle.PeriodicTasks.EventBus/TriggerPeriodicTaskEventConsumer.cs
@@ -38,10 +38,9 @@ internal class TriggerPeriodicTaskEventConsumer : IEventConsumer<TriggerPeriodic
         var runner = (IPeriodicTaskRunner)provider.GetRequiredService(runnerType);
 
         // execute
-        var t = runner.ExecuteAsync(name: name, throwOnError: request.Throw, cancellationToken: cancellationToken);
-        if (request.Wait)
-        {
-            await t.ConfigureAwait(false);
-        }
+        await runner.ExecuteAsync(name: name,
+                                  throwOnError: request.Throw,
+                                  awaitExecution: request.Wait,
+                                  cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Tingle.PeriodicTasks/Extensions/IHostExtensions.cs
+++ b/src/Tingle.PeriodicTasks/Extensions/IHostExtensions.cs
@@ -15,14 +15,21 @@ public static class IHostExtensions
     /// </summary>
     /// <param name="host">The <see cref="IHost"/> to use.</param>
     /// <param name="throwOnError">Whether to throw an exception on failure.</param>
+    /// <param name="awaitExecution">
+    /// Gets or sets whether the task execution should be awaited.
+    /// This overrides the value in <see cref="PeriodicTaskOptions.AwaitExecution"/>.
+    /// </param>
     /// <param name="cancellationToken">The token to trigger termination or shutdown.</param>
     /// <returns></returns>
-    public static Task RunOrExecutePeriodicTaskAsync(this IHost host, bool throwOnError = true, CancellationToken cancellationToken = default)
+    public static Task RunOrExecutePeriodicTaskAsync(this IHost host,
+                                                     bool throwOnError = true,
+                                                     bool? awaitExecution = null,
+                                                     CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(host);
 
         return host.TryGetPeriodicTaskName(out var taskName)
-            ? host.ExecutePeriodicTaskAsync(taskName, throwOnError, cancellationToken)
+            ? host.ExecutePeriodicTaskAsync(taskName, throwOnError, awaitExecution, cancellationToken)
             : host.RunAsync(cancellationToken);
     }
 
@@ -37,7 +44,7 @@ public static class IHostExtensions
     /// This parameter is passed uninitialized.
     /// <br/>
     /// This value can be used with
-    /// <see cref="ExecutePeriodicTaskAsync(IHost, string, bool, CancellationToken)"/>.
+    /// <see cref="ExecutePeriodicTaskAsync(IHost, string, bool, bool?, CancellationToken)"/>.
     /// </param>
     /// <returns>
     /// <see langword="true"/> if the <see cref="IConfiguration"/> used by the <see cref="IHost"/>
@@ -56,9 +63,17 @@ public static class IHostExtensions
     /// <param name="host">The <see cref="IHost"/> to use.</param>
     /// <param name="name">The name of the periodic task.</param>
     /// <param name="throwOnError">Whether to throw an exception on failure.</param>
+    /// <param name="awaitExecution">
+    /// Gets or sets whether the task execution should be awaited.
+    /// This overrides the value in <see cref="PeriodicTaskOptions.AwaitExecution"/>.
+    /// </param>
     /// <param name="cancellationToken">The token to trigger termination.</param>
     /// <returns></returns>
-    public static Task ExecutePeriodicTaskAsync(this IHost host, string name, bool throwOnError = true, CancellationToken cancellationToken = default)
+    public static Task ExecutePeriodicTaskAsync(this IHost host,
+                                                string name,
+                                                bool throwOnError = true,
+                                                bool? awaitExecution = null,
+                                                CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(host);
         ArgumentNullException.ThrowIfNull(name);
@@ -87,6 +102,9 @@ public static class IHostExtensions
         var genericRunnerType = typeof(IPeriodicTaskRunner<>);
         var runnerType = genericRunnerType.MakeGenericType(type);
         var runner = (IPeriodicTaskRunner)provider.GetRequiredService(runnerType);
-        return runner.ExecuteAsync(name: name, throwOnError: throwOnError, cancellationToken: cts.Token);
+        return runner.ExecuteAsync(name: name,
+                                   throwOnError: throwOnError,
+                                   awaitExecution: awaitExecution,
+                                   cancellationToken: cts.Token);
     }
 }

--- a/src/Tingle.PeriodicTasks/Extensions/IHostExtensions.cs
+++ b/src/Tingle.PeriodicTasks/Extensions/IHostExtensions.cs
@@ -14,14 +14,15 @@ public static class IHostExtensions
     /// If none is present or if <see langowrd="null"/>, the host is run instead using <c>host.RunAsync(cancellationToken)</c>.
     /// </summary>
     /// <param name="host">The <see cref="IHost"/> to use.</param>
+    /// <param name="throwOnError">Whether to throw an exception on failure.</param>
     /// <param name="cancellationToken">The token to trigger termination or shutdown.</param>
     /// <returns></returns>
-    public static Task RunOrExecutePeriodicTaskAsync(this IHost host, CancellationToken cancellationToken = default)
+    public static Task RunOrExecutePeriodicTaskAsync(this IHost host, bool throwOnError = true, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(host);
 
         return host.TryGetPeriodicTaskName(out var taskName)
-            ? host.ExecutePeriodicTaskAsync(taskName, cancellationToken)
+            ? host.ExecutePeriodicTaskAsync(taskName, throwOnError, cancellationToken)
             : host.RunAsync(cancellationToken);
     }
 
@@ -36,7 +37,7 @@ public static class IHostExtensions
     /// This parameter is passed uninitialized.
     /// <br/>
     /// This value can be used with
-    /// <see cref="ExecutePeriodicTaskAsync(IHost, string, CancellationToken)"/>.
+    /// <see cref="ExecutePeriodicTaskAsync(IHost, string, bool, CancellationToken)"/>.
     /// </param>
     /// <returns>
     /// <see langword="true"/> if the <see cref="IConfiguration"/> used by the <see cref="IHost"/>
@@ -54,9 +55,10 @@ public static class IHostExtensions
     /// <summary>Execute a periodic task.</summary>
     /// <param name="host">The <see cref="IHost"/> to use.</param>
     /// <param name="name">The name of the periodic task.</param>
+    /// <param name="throwOnError">Whether to throw an exception on failure.</param>
     /// <param name="cancellationToken">The token to trigger termination.</param>
     /// <returns></returns>
-    public static Task ExecutePeriodicTaskAsync(this IHost host, string name, CancellationToken cancellationToken = default)
+    public static Task ExecutePeriodicTaskAsync(this IHost host, string name, bool throwOnError = true, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(host);
         ArgumentNullException.ThrowIfNull(name);
@@ -85,6 +87,6 @@ public static class IHostExtensions
         var genericRunnerType = typeof(IPeriodicTaskRunner<>);
         var runnerType = genericRunnerType.MakeGenericType(type);
         var runner = (IPeriodicTaskRunner)provider.GetRequiredService(runnerType);
-        return runner.ExecuteAsync(name: name, throwOnError: true, cancellationToken: cts.Token);
+        return runner.ExecuteAsync(name: name, throwOnError: throwOnError, cancellationToken: cts.Token);
     }
 }

--- a/src/Tingle.PeriodicTasks/IPeriodicTaskRunner.cs
+++ b/src/Tingle.PeriodicTasks/IPeriodicTaskRunner.cs
@@ -22,13 +22,17 @@ public interface IPeriodicTaskRunner
     /// <summary>Execute the task once.</summary>
     /// <param name="name">Name of the task.</param>
     /// <param name="throwOnError">Whether to throw an exception on failure.</param>
+    /// <param name="awaitExecution">
+    /// Gets or sets whether the task execution should be awaited.
+    /// This overrides the value in <see cref="PeriodicTaskOptions.AwaitExecution"/>.
+    /// </param>
     /// <param name="cancellationToken">A token to cancel execution.</param>
     /// <returns></returns>
     /// <remarks>
     /// Use this method if your application needs to execute the task
     /// before the next schedule is reached or if the task is disabled.
     /// </remarks>
-    Task ExecuteAsync(string name, bool throwOnError, CancellationToken cancellationToken = default);
+    Task ExecuteAsync(string name, bool throwOnError, bool? awaitExecution, CancellationToken cancellationToken = default);
 }
 
 /// <summary>A periodic task runner tasks of <typeparamref name="TTask"/> type.</summary>

--- a/src/Tingle.PeriodicTasks/Internal/PeriodicTaskRunner.cs
+++ b/src/Tingle.PeriodicTasks/Internal/PeriodicTaskRunner.cs
@@ -157,11 +157,7 @@ internal class PeriodicTaskRunner<TTask> : IPeriodicTaskRunner<TTask>
         catch (Exception ex)
         {
             Interlocked.Exchange(ref caught, ex);
-
-            if (!throwOnError)
-            {
-                logger.ExceptionInPeriodicTask(ex, executionId);
-            }
+            logger.ExceptionInPeriodicTask(ex, executionId);
         }
 
         var end = DateTimeOffset.UtcNow;

--- a/src/Tingle.PeriodicTasks/Internal/PeriodicTaskRunner.cs
+++ b/src/Tingle.PeriodicTasks/Internal/PeriodicTaskRunner.cs
@@ -75,9 +75,9 @@ internal class PeriodicTaskRunner<TTask> : IPeriodicTaskRunner<TTask>
     }
 
     public Task ExecuteAsync(string name, CancellationToken cancellationToken = default)
-        => ExecuteAsync(name: name, throwOnError: false, cancellationToken: cancellationToken);
+        => ExecuteAsync(name: name, throwOnError: false, awaitExecution: null, cancellationToken: cancellationToken);
 
-    public async Task ExecuteAsync(string name, bool throwOnError, CancellationToken cancellationToken = default)
+    public async Task ExecuteAsync(string name, bool throwOnError, bool? awaitExecution, CancellationToken cancellationToken = default)
     {
         var options = optionsMonitor.Get(name);
 
@@ -93,7 +93,7 @@ internal class PeriodicTaskRunner<TTask> : IPeriodicTaskRunner<TTask>
                                   throwOnError: throwOnError,
                                   cancellationToken: cts.Token);
 
-        if (options.AwaitExecution)
+        if (awaitExecution ?? options.AwaitExecution)
         {
             try
             {


### PR DESCRIPTION
Allow passing of `throwOnError` and `awaitExecution` to the runner when executing from outside `IHostedService`. This is usefull for AspNetCore and one time runs such as inside Container App Jobs.

Also changed logging of exceptions in the execution to always be done even if it is not to be thrown.