### PR TITLE
Remove SourceLink package

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,7 +31,6 @@
 
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is redundant now as it's built in to the .NET 8 SDK.