### PR TITLE
Add sample for using `CronScheduleTimer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,15 @@ resource job 'Microsoft.App/jobs@2023-05-01' = {
 }
 ```
 
+## Low Level logic
+
+### `CronScheduleTimer`
+
+Sometimes, using DI is not necessary/sufficient and you want to control the logic yourself. In this case, you can use `CronScheduleTimer`. [Local sample](./samples/TimerSample), real-life example: <https://github.com/tinglesoftware/dependabot-azure-devops>.
+
+> [!IMPORTANT]
+> Using `CronScheduleTimer` you loose lots of features such as instrumentation and retries but you can add what suits you.
+
 ## Samples
 
 - [Simple sample setup](./samples/SimpleSample)
@@ -243,6 +252,7 @@ resource job 'Microsoft.App/jobs@2023-05-01' = {
 - [Save executions to a database using Entity Framework](./samples/EFCoreStoreSample)
 - [Add retries using Polly's Resilience Pipelines](./samples/ResilienceSample/)
 - [Publishing AOT](./samples/AotSample)
+- [Timer sample (advanced)](./samples/TimerSample)
 
 ## Issues &amp; Comments
 

--- a/Tingle.PeriodicTasks.slnx
+++ b/Tingle.PeriodicTasks.slnx
@@ -20,5 +20,6 @@
     <Project Path="samples/EventBusSample/EventBusSample.csproj" />
     <Project Path="samples/ResilienceSample/ResilienceSample.csproj" />
     <Project Path="samples/SimpleSample/SimpleSample.csproj" />
+    <Project Path="samples/TimerSample/TimerSample.csproj" />
   </Folder>
 </Solution>

--- a/samples/TimerSample/Program.cs
+++ b/samples/TimerSample/Program.cs
@@ -1,0 +1,39 @@
+using Tingle.PeriodicTasks;
+
+var databaseTimer = new CronScheduleTimer("*/1 * * * *", async (_, cancellationToken) =>
+{
+    Console.WriteLine("Cleaned up old records from the database");
+    await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+});
+var dnsTimer = new CronScheduleTimer("*/5 * * * * *", async (_, cancellationToken) =>
+{
+    Console.WriteLine("All DNS records are fine");
+    await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+});
+
+using var cts = new CancellationTokenSource();
+
+// Listen for Ctrl+C or SIGINT
+Console.CancelKeyPress += (sender, eventArgs) =>
+{
+    cts.Cancel();                // Trigger the token
+    eventArgs.Cancel = true;     // Prevent immediate shutdown
+};
+
+var cancellationToken = cts.Token;
+Console.WriteLine("Started timers.");
+Console.WriteLine("Press Ctrl+C to exit...");
+await databaseTimer.StartAsync(cancellationToken);
+await dnsTimer.StartAsync(cancellationToken);
+
+try
+{
+    // Wait for the cancellation token to be triggered
+    await Task.Delay(Timeout.Infinite, cancellationToken);
+}
+catch (TaskCanceledException) { }
+finally
+{
+    await databaseTimer.StopAsync();
+    await dnsTimer.StopAsync();
+}

--- a/samples/TimerSample/Properties/launchSettings.json
+++ b/samples/TimerSample/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+﻿{
+  "profiles": {
+    "TimerSample": {
+      "commandName": "Project",
+      "dotnetRunMessages": true
+    }
+  }
+}

--- a/samples/TimerSample/TimerSample.csproj
+++ b/samples/TimerSample/TimerSample.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Tingle.PeriodicTasks\Tingle.PeriodicTasks.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
`CronScheduleTimer` is useful in simple situations where the whole host logic is not necessary such as dynamic schedules (Example: https://github.com/tinglesoftware/dependabot-azure-devops).