### PR TITLE
Added JSON converter for `CronSchedule`

### DIFF
--- a/src/Tingle.PeriodicTasks/CronSchedule.cs
+++ b/src/Tingle.PeriodicTasks/CronSchedule.cs
@@ -1,10 +1,12 @@
 ﻿using Cronos;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace Tingle.PeriodicTasks;
 
 /// <summary>Represents a CRON schedule.</summary>
+[JsonConverter(typeof(CronScheduleJsonConverter))]
 [TypeConverter(typeof(CronScheduleTypeConverter))]
 public readonly struct CronSchedule : IEquatable<CronSchedule>, IConvertible
 {

--- a/src/Tingle.PeriodicTasks/CronScheduleJsonConverter.cs
+++ b/src/Tingle.PeriodicTasks/CronScheduleJsonConverter.cs
@@ -1,0 +1,29 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Tingle.PeriodicTasks;
+
+/// <summary>
+/// A <see cref="JsonConverter{T}"/> for <see cref="CronSchedule"/>
+/// </summary>
+public class CronScheduleJsonConverter : JsonConverter<CronSchedule>
+{
+    /// <inheritdoc/>
+    public override CronSchedule Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null) return default;
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new InvalidOperationException("Only strings are supported");
+        }
+
+        var value = reader.GetString()!;
+        return CronSchedule.Parse(value);
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, CronSchedule value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}

--- a/tests/Tingle.PeriodicTasks.Tests/CronScheduleTests.cs
+++ b/tests/Tingle.PeriodicTasks.Tests/CronScheduleTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Tingle.PeriodicTasks.Tests;
+﻿using System.Text.Json;
+
+namespace Tingle.PeriodicTasks.Tests;
 
 public class CronScheduleTests
 {
@@ -69,5 +71,33 @@ public class CronScheduleTests
 
         Assert.Equal("0 * * * *", ((IConvertible)value).ToType(typeof(string), null));
         Assert.Throws<InvalidCastException>(() => ((IConvertible)value).ToType(typeof(ulong), null));
+    }
+
+    [Fact]
+    public void JsonConverter_Works()
+    {
+        var src_json = "{\"id\":\"0 * * * *\"}";
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        var model = JsonSerializer.Deserialize<TestModel>(src_json, options);
+        var dst_json = JsonSerializer.Serialize(model, options);
+        Assert.Equal(src_json, dst_json);
+        Assert.Equal(CronSchedule.Parse("0 * * * *"), model!.Id);
+    }
+
+    [Fact]
+    public void JsonSerializerContext_Works()
+    {
+        var src_json = "{\"id\":\"0 * * * *\"}";
+        var model = JsonSerializer.Deserialize(src_json, TestJsonSerializerContext.Default.CronScheduleTests_TestModel)!;
+        var dst_json = JsonSerializer.Serialize(model, TestJsonSerializerContext.Default.CronScheduleTests_TestModel);
+        Assert.Equal(src_json, dst_json);
+    }
+
+    internal class TestModel
+    {
+        public CronSchedule? Id { get; set; }
     }
 }

--- a/tests/Tingle.PeriodicTasks.Tests/TestJsonSerializerContext.cs
+++ b/tests/Tingle.PeriodicTasks.Tests/TestJsonSerializerContext.cs
@@ -1,0 +1,7 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Tingle.PeriodicTasks.Tests;
+
+[JsonSerializable(typeof(CronScheduleTests.TestModel), TypeInfoPropertyName = "CronScheduleTests_TestModel")]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal partial class TestJsonSerializerContext : JsonSerializerContext { }


### PR DESCRIPTION
This complements the existing TypeConverter and allows the CronSchedule object to be used in serializable models.